### PR TITLE
Fix Starknet contract calls to use withOptions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -370,8 +370,7 @@ export default function App() {
       setRejected(false);
 
       const saltVal = BigInt(salt || "0");
-      const overrides = { value: feeWei };
-      const tx = await contract.play(saltVal, overrides);
+      const tx = await contract.withOptions({ value: feeWei }).play(saltVal);
       addLog({ text: `play(tx: ${shortHash(tx.hash)})`, txHash: tx.hash });
       
       const rcpt = await tx.wait();
@@ -512,7 +511,9 @@ export default function App() {
       setStatus("");
       setProgressMessage("Funding in action...");
       setRejected(false);
-      const tx = await contract.fund({ value: parseEther(amountEth || "0") });
+      const tx = await contract
+        .withOptions({ value: parseEther(amountEth || "0") })
+        .fund();
       addLog({
         text: `fund ${amountEth} ETH (tx: ${shortHash(tx.hash)})`,
         txHash: tx.hash,


### PR DESCRIPTION
## Summary
- adjust `play` invocation to use `withOptions` so calling the contract sends value without argument mismatch
- apply the same `withOptions` pattern to `fund` to prevent similar errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4d6912d68832f875f5fca713c7a8c