### PR TITLE
Load contract address from env and align ABI with deployed contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ The static site is in `dist/` — perfect for Vercel/Netlify.
 
 ## Configure
 
-- Contract address is set in `src/App.jsx` (`CONTRACT_ADDRESS`).
+- Set the deployed contract address via the `VITE_CONTRACT_ADDRESS` environment
+  variable (falls back to the default in `src/App.jsx`).
 - Uses ethers v6. RNG uses block data (not secure for big prizes).
 
 ## How it works

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,11 @@ import { formatEther, parseEther } from "ethers";
 import { Contract, uint256 } from "starknet";
 import logo from "./assets/tubbly-logo.svg";
 
-const CONTRACT_ADDRESS = "0x75d13ac0cb15587532e4c1a208d3ffddf97fb60c35c7be3b891388054def324";
+// Address of the deployed lottery contract
+// Can be overridden via VITE_CONTRACT_ADDRESS env variable for flexibility
+const CONTRACT_ADDRESS =
+  import.meta.env.VITE_CONTRACT_ADDRESS ||
+  "0x75d13ac0cb15587532e4c1a208d3ffddf97fb60c35c7be3b891388054def324";
 
 // Minimal ABI for the functions/events we use
 const ABI = [
@@ -40,7 +44,7 @@ const ABI = [
   { "type": "event", "name": "Result", "inputs": [
       { "name": "player", "type": "felt", "indexed": true },
       { "name": "won", "type": "bool", "indexed": false },
-      { "name": "prizeAmount", "type": "uint256", "indexed": false }
+      { "name": "prize_amount", "type": "uint256", "indexed": false }
   ] },
   { "type": "event", "name": "PrizePaid", "inputs": [
       { "name": "to", "type": "felt", "indexed": true },
@@ -51,9 +55,9 @@ const ABI = [
       { "name": "amount", "type": "uint256", "indexed": false }
   ] },
   { "type": "event", "name": "ParamsUpdated", "inputs": [
-      { "name": "prizeWei", "type": "uint256", "indexed": false },
-      { "name": "entryFeeWei", "type": "uint256", "indexed": false },
-      { "name": "winChancePpm", "type": "uint32", "indexed": false }
+      { "name": "prize_wei", "type": "uint256", "indexed": false },
+      { "name": "entry_fee_wei", "type": "uint256", "indexed": false },
+      { "name": "win_chance_ppm", "type": "uint32", "indexed": false }
   ] },
 ];
 
@@ -348,7 +352,7 @@ export default function App() {
             if (type === "Result") {
               return {
                 text: ev.args.won
-                  ? `Result → WIN ${formatEther(ev.args.prizeAmount)} ETH`
+                  ? `Result → WIN ${formatEther(ev.args.prize_amount)} ETH`
                   : "Result → Loss",
                 txHash: ev.transactionHash,
               };
@@ -411,10 +415,10 @@ export default function App() {
             const parsed = contract.interface.parseLog(log);
             if (parsed?.name === "Result") {
               won = parsed.args.won;
-              prize = toBigInt(parsed.args.prizeAmount);
+              prize = toBigInt(parsed.args.prize_amount);
               addLog({
                 text: parsed.args.won
-                  ? `Result → WIN ${formatEther(toBigInt(parsed.args.prizeAmount))} ETH`
+                  ? `Result → WIN ${formatEther(toBigInt(parsed.args.prize_amount))} ETH`
                   : "Result → Loss",
                 txHash: rcpt.transaction_hash || rcpt.transactionHash,
               });


### PR DESCRIPTION
## Summary
- allow overriding lottery contract address via `VITE_CONTRACT_ADDRESS`
- synchronize ABI and event names with on-chain contract
- document contract address configuration

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4e0b85c0c832fa8e15990026b5143