### PR TITLE
Fix contract getter names for lottery contract

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,11 +17,11 @@ const FN = {
   winChancePpm: "winChancePpm",
   owner: "owner",
   contractBalance: "contractBalance",
-  // Older deployed contract exposes camelCase entrypoints
-  getUserLastPlayedBlock: "getUserLastPlayedBlock",
-  getPendingPrizes: "getPendingPrizes",
-  getCanPlay: "getCanPlay",
-  getNextAllowedBlock: "getNextAllowedBlock",
+  // Deployed contract exposes snake_case getters
+  getUserLastPlayedBlock: "get_user_last_played_block",
+  getPendingPrizes: "get_pending_prizes",
+  getCanPlay: "get_can_play",
+  getNextAllowedBlock: "get_next_allowed_block",
   play: "play",
   claim: "claim",
   fund: "fund",


### PR DESCRIPTION
## Summary
- align frontend contract getters with snake_case entrypoints used by deployed contract

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4ece63920832fbddb048fe6584ef3